### PR TITLE
Drop @wdio/sync as a devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@wdio/local-runner": "^7.26.0",
         "@wdio/mocha-framework": "^7.26.0",
         "@wdio/spec-reporter": "^7.26.0",
-        "@wdio/sync": "^7.26.0",
         "eslint": "^8.27.0",
         "eslint-config-prettier": "^8.5.0",
         "husky": "^8.0.2",
@@ -1198,12 +1197,6 @@
       "integrity": "sha512-DCg+Ka+uDQ31lJ/UtEXVlaeV3d6t81gifaVWKJy4MYVVgvJttyX/viREy+If7fz+tK/gVxTGMtyrFPnm4gjrVA==",
       "dev": true
     },
-    "node_modules/@types/fibers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/fibers/-/fibers-3.1.1.tgz",
-      "integrity": "sha512-yHoUi46uika0snoTpNcVqUSvgbRndaIps4TUCotrXjtc0DHDoPQckmyXEZ2bX3e4mpJmyEW3hRhCwQa/ISCPaA==",
-      "dev": true
-    },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
@@ -1343,15 +1336,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
-    },
-    "node_modules/@types/puppeteer": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.4.tgz",
-      "integrity": "sha512-3Nau+qi69CN55VwZb0ATtdUAlYlqOOQ3OfQfq0Hqgc4JMFXiQT/XInlwQ9g6LbicDslE6loIFsXFklGh5XmI6Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/recursive-readdir": {
       "version": "2.2.0",
@@ -1910,23 +1894,6 @@
       },
       "peerDependencies": {
         "@wdio/cli": "^7.0.0"
-      }
-    },
-    "node_modules/@wdio/sync": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@wdio/sync/-/sync-7.26.0.tgz",
-      "integrity": "sha512-XrBg4t7BrQHTfg5oD8BK87EbQJtoWANnC2FaIMblAWLowS+gZOdy30hWyLloFXaf1oambnO1bZVMjvgdUShi4A==",
-      "dev": true,
-      "dependencies": {
-        "@types/fibers": "^3.1.0",
-        "@types/puppeteer": "^5.4.0",
-        "@wdio/logger": "7.26.0",
-        "@wdio/types": "7.26.0",
-        "fibers": "5.0.3",
-        "webdriverio": "7.26.0"
-      },
-      "engines": {
-        "node": ">=12.0.0 <16"
       }
     },
     "node_modules/@wdio/types": {
@@ -3366,18 +3333,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -4247,19 +4202,6 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fibers": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.3.tgz",
-      "integrity": "sha512-/qYTSoZydQkM21qZpGLDLuCq8c+B8KhuCQ1kLPvnRNhxhVbvrpmH9l2+Lblf5neDuEsY4bfT7LeO553TXQDvJw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/figures": {
@@ -10826,12 +10768,6 @@
       "integrity": "sha512-DCg+Ka+uDQ31lJ/UtEXVlaeV3d6t81gifaVWKJy4MYVVgvJttyX/viREy+If7fz+tK/gVxTGMtyrFPnm4gjrVA==",
       "dev": true
     },
-    "@types/fibers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/fibers/-/fibers-3.1.1.tgz",
-      "integrity": "sha512-yHoUi46uika0snoTpNcVqUSvgbRndaIps4TUCotrXjtc0DHDoPQckmyXEZ2bX3e4mpJmyEW3hRhCwQa/ISCPaA==",
-      "dev": true
-    },
     "@types/fs-extra": {
       "version": "9.0.13",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
@@ -10971,15 +10907,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
-    },
-    "@types/puppeteer": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.4.tgz",
-      "integrity": "sha512-3Nau+qi69CN55VwZb0ATtdUAlYlqOOQ3OfQfq0Hqgc4JMFXiQT/XInlwQ9g6LbicDslE6loIFsXFklGh5XmI6Q==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/recursive-readdir": {
       "version": "2.2.0",
@@ -11390,20 +11317,6 @@
         "chalk": "^4.0.0",
         "easy-table": "^1.1.1",
         "pretty-ms": "^7.0.0"
-      }
-    },
-    "@wdio/sync": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@wdio/sync/-/sync-7.26.0.tgz",
-      "integrity": "sha512-XrBg4t7BrQHTfg5oD8BK87EbQJtoWANnC2FaIMblAWLowS+gZOdy30hWyLloFXaf1oambnO1bZVMjvgdUShi4A==",
-      "dev": true,
-      "requires": {
-        "@types/fibers": "^3.1.0",
-        "@types/puppeteer": "^5.4.0",
-        "@wdio/logger": "7.26.0",
-        "@wdio/types": "7.26.0",
-        "fibers": "5.0.3",
-        "webdriverio": "7.26.0"
       }
     },
     "@wdio/types": {
@@ -12507,12 +12420,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true
-    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -13174,15 +13081,6 @@
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
-      }
-    },
-    "fibers": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.3.tgz",
-      "integrity": "sha512-/qYTSoZydQkM21qZpGLDLuCq8c+B8KhuCQ1kLPvnRNhxhVbvrpmH9l2+Lblf5neDuEsY4bfT7LeO553TXQDvJw==",
-      "dev": true,
-      "requires": {
-        "detect-libc": "^1.0.3"
       }
     },
     "figures": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@wdio/local-runner": "^7.26.0",
     "@wdio/mocha-framework": "^7.26.0",
     "@wdio/spec-reporter": "^7.26.0",
-    "@wdio/sync": "^7.26.0",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
     "husky": "^8.0.2",


### PR DESCRIPTION
_Description of changes:_

WebDriverIO has deprecated the `@wdio/sync` library - is currently not used in our package. Simple removal.

https://webdriver.io/docs/async-migration
https://webdriver.io/blog/2021/07/28/sync-api-deprecation/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
