### PR TITLE
Drop support for Node.JS 10 (and 11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "aws-sdk": "^2.991.0"
       },
       "devDependencies": {
-        "@tsconfig/node10": "^1.0.9",
+        "@tsconfig/node12": "^1.0.0",
         "@types/jest": "^27.0.2",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/eslint-plugin-tslint": "^5.43.0",
@@ -32,7 +32,7 @@
         "typescript": "^4.4.3"
       },
       "engines": {
-        "node": ">= 0.12.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1110,10 +1110,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true
     },
     "node_modules/@types/aria-query": {
@@ -10682,10 +10682,10 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true
     },
     "@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "Florian Nagel <fnagel@amazon.com>",
     "Hector Gavin Rivas <hecgav@amazon.com>",
     "Javier Luna Molina <jlunamol@amazon.com>",
-    "Michal Pasierbski <mpasierb@amazon.com>"
+    "Arnulfo Solis Ramirez <arnsolis@amazon.com>"
   ],
   "bugs": {
     "url": "https://github.com/awslabs/wdio-aws-device-farm-service/issues"
@@ -33,7 +33,7 @@
     "!/**/__tests__"
   ],
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc",
@@ -49,7 +49,7 @@
     "aws-sdk": "^2.991.0"
   },
   "devDependencies": {
-    "@tsconfig/node10": "^1.0.9",
+    "@tsconfig/node12": "^1.0.0",
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/eslint-plugin-tslint": "^5.43.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node10/tsconfig.json",
+  "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
_Description of changes:_

WebDriverIO dropped support for Node.JS 10 starting from v7.
https://github.com/webdriverio/webdriverio/blob/v7/CHANGELOG.md#v700-2021-02-09
https://github.com/webdriverio/webdriverio/pull/6236

WebDriverIO v8 drops support for Node.JS 12, 13, and 14.
https://github.com/webdriverio/webdriverio/blob/main/CHANGELOG.md#boom-breaking-change

To start slowly, lets drop support for Node.JS 10 altogether. This changes will:

- emit transpiled JS code targeting node12
- print warning when using a version of nodejs lesser than 12.

Also some consmetic updates to the contributors list.

This will be released under a minor version bump `v7.1.0` to allow consumers to pin the version using `~7.0.7` instead of `^7.0.0`. It is definitely not a major version bump.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
