### PR TITLE
Set remote session for Testrunner Options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wdio-aws-device-farm-service",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wdio-aws-device-farm-service",
-      "version": "8.0.5",
+      "version": "8.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-device-farm": "^3.363.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-aws-device-farm-service",
-  "version": "8.1.0",
+  "version": "8.0.6",
   "description": "AWS Device Farm support for WebdriverIO",
   "keywords": [
     "aws",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-aws-device-farm-service",
-  "version": "8.0.5",
+  "version": "8.1.0",
   "description": "AWS Device Farm support for WebdriverIO",
   "keywords": [
     "aws",

--- a/src/__tests__/launcher.test.ts
+++ b/src/__tests__/launcher.test.ts
@@ -22,8 +22,8 @@ describe("DeviceFarmLauncher", () => {
     vi.resetAllMocks();
   });
 
-  it("Updates capabilities with destination", async () => {
-    createTestGridUrlResponse.mockReturnValueOnce({
+  it("Updates capabilities & config with destination", async () => {
+    createTestGridUrlResponse.mockReturnValue({
       url: "https://devicefarm.url/id",
     });
 
@@ -39,6 +39,14 @@ describe("DeviceFarmLauncher", () => {
       path: "/id",
       port: 443,
       browserName: "chrome",
+      connectionRetryTimeout: 180000,
+    });
+
+    expect(config).toEqual({
+      protocol: "https",
+      hostname: "devicefarm.url",
+      path: "/id",
+      port: 443,
       connectionRetryTimeout: 180000,
     });
   });


### PR DESCRIPTION
_Description of changes:_

Setting remote session for Testrunner Options too. The newest WebdriverIO version uses it to decide if setting up driver can be skipped. We do want to skip this step when running cross browser tests on device farm.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
